### PR TITLE
Add sales channel search field to main menu

### DIFF
--- a/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
+++ b/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
@@ -227,6 +227,16 @@ $sw-admin-menu-shop-status-ok: $color-emerald;
         font-weight: bold;
     }
 
+    .sw-sales-channel-menu {
+        .sw-admin-menu__sales-channel-search {
+            padding: 0 30px 12px;
+
+            .sw-field--sales-channel-search {
+                margin-bottom: 0;
+            }
+        }
+    }
+
     .sw-admin-menu__flyout {
         background-color: $sw-admin-menu-color-active;
         min-width: $sw-admin-menu-width-flyout;
@@ -388,6 +398,10 @@ $sw-admin-menu-shop-status-ok: $color-emerald;
     }
 
     &.is--collapsed {
+        .sw-admin-menu__sales-channel-search {
+            display: none;
+        }
+
         .sw-admin-menu__user-actions {
             border-left: 2px solid $sw-admin-menu-color-text-secondary;
             left: $sw-admin-menu-width-collapsed;

--- a/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
+++ b/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
@@ -13,7 +13,8 @@ Component.register('sw-sales-channel-menu', {
         return {
             salesChannels: [],
             menuItems: [],
-            showModal: false
+            showModal: false,
+            searchTerm: ''
         };
     },
 
@@ -51,8 +52,16 @@ Component.register('sw-sales-channel-menu', {
             this.$root.$off('on-change-application-language', this.loadEntityData);
         },
 
+        onSearchTermChange() {
+            this.loadEntityData();
+        },
+
         loadEntityData() {
             const criteria = new Criteria();
+
+            if (this.searchTerm.trim().length) {
+                criteria.addFilter(Criteria.contains('sales_channel.name', this.searchTerm.trim()));
+            }
 
             criteria.setPage(1);
             criteria.setLimit(500);

--- a/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.html.twig
+++ b/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.html.twig
@@ -24,6 +24,16 @@
         {% block sw_sales_channel_menu_navigation %}
             <nav class="sw-admin-menu__navigation">
 
+                {% block sw_sales_channel_menu_navigation_main_list_search %}
+                    <div v-if="menuItems.length >= 10 || searchTerm.length"
+                         class="sw-admin-menu__sales-channel-search collapsible-text">
+                        <sw-simple-search-field class="sw-field--sales-channel-search"
+                                                v-model="searchTerm"
+                                                @search-term-change="onSearchTermChange">
+                        </sw-simple-search-field>
+                    </div>
+                {% endblock %}
+
                 {% block sw_sales_channel_menu_navigation_main_list %}
                     <ul class="sw-admin-menu__navigation-list">
 


### PR DESCRIPTION
This pull request adds an input field to search for search channels, when there are more than 10, for better usability when working with a lot of sales channels.
I'm not sure, if the amount of 10 is the best threshold to display that field, so let's discuss about this. :slightly_smiling_face: 
The input field is hidden, when the main menu is collapsed.

If there are any problems with the styling, you are welcome to offer a more suitable design, which I can then adapt.

Here are some Screenshots, showing how it looks now:
![image](https://user-images.githubusercontent.com/1217881/97081489-0c2e3580-1603-11eb-83f5-c7a24fdc33f1.png) ![image](https://user-images.githubusercontent.com/1217881/97081503-1d774200-1603-11eb-885f-c052618553d0.png) ![image](https://user-images.githubusercontent.com/1217881/97081519-40095b00-1603-11eb-804f-5aa6db7bc33a.png)