### PR TITLE
Make sure access key generation for user uses right access point

### DIFF
--- a/Resources/app/administration/src/core/service/api/integration.api.service.js
+++ b/Resources/app/administration/src/core/service/api/integration.api.service.js
@@ -18,12 +18,13 @@ class IntegrationApiService extends ApiService {
      * @param {Object} [additionalHeaders = {}]
      * @returns {Promise<T>}
      */
-    generateKey(additionalParams = {}, additionalHeaders = {}) {
+    generateKey(additionalParams = {}, additionalHeaders = {}, user = false) {
         const params = additionalParams;
         const headers = this.getBasicHeaders(additionalHeaders);
+        const endpoint = user ? '/_action/access-key/user' : '/_action/access-key/intergration';
 
         return this.httpClient
-            .get('/_action/access-key/intergration', {
+            .get(endpoint, {
                 params,
                 headers,
             })

--- a/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -257,7 +257,7 @@ Component.register('sw-users-permissions-user-detail', {
 
             this.isModalLoading = true;
             newKey.quantityStart = 1;
-            this.integrationService.generateKey().then((response) => {
+            this.integrationService.generateKey({}, {}, true).then((response) => {
                 newKey.accessKey = response.accessKey;
                 newKey.secretAccessKey = response.secretAccessKey;
                 this.currentIntegration = newKey;


### PR DESCRIPTION
In the Administration, you can generate an Access Key for an user via the window **Settings > System > Users & Permissions** under the tab **Integrations** of a specific user. When generating this Access Key, it starts with `SWIA` instead of `SWUA`, marking it as an Access Key for an integration, instead of an Access Key for an user. Because of this, the credentials will never work: A POST request to `api/oauth/token` will always return an error `The user credentials were incorrect`.

To fix this, the Access Key needs to be prefixed with `SWUA`, which can be done by using the endpoint `_action/access-key/user` instead of `_action/access-key/intergration`. This PR makes that fix possible for the `sw-users-permissions-user-detail` component while the functionality of the original integration page (under **Settings > System > Integrations**) is left untouched.

We found out about this during a Shopware 6 training together with @riconeitzel, Rick Schippers, Bjorn Meyer and others.