### PR TITLE
NEXT-19250 get orders with technical state paid

### DIFF
--- a/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
+++ b/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
@@ -417,7 +417,7 @@ Component.register('sw-dashboard-index', {
 
             criteria.addAssociation('stateMachineState');
 
-            criteria.addFilter(Criteria.equals('transactions.stateMachineState.name', 'paid'));
+            criteria.addFilter(Criteria.equals('transactions.stateMachineState.technicalName', 'paid'));
             criteria.addFilter(Criteria.range('orderDate', { gte: this.formatDate(this.dateAgo) }));
 
             return this.orderRepository.search(criteria);


### PR DESCRIPTION
use `technicalName` instead of `name` because name would be the name field of the table `state_machine_translation` which is not loaded via association (and it might not even be equal to the string "paid")

https://issues.shopware.com/issues/NEXT-19250