### PR TITLE
Template Registry override issue

### DIFF
--- a/Resources/app/administration/src/core/factory/template.factory.js
+++ b/Resources/app/administration/src/core/factory/template.factory.js
@@ -197,6 +197,7 @@ function registerTemplateOverride(
         index: overrideIndex,
         raw: templateOverride,
     });
+    component.overrides.sort((a,b) => a.index - b.index);
     templateRegistry.set(componentName, component);
     return true;
 }


### PR DESCRIPTION
Found a little issue with the template override order.
It is possible to define an overrideIndex but it is never used.

My idea was to sort the overrides after adding a new one.